### PR TITLE
fix nequip.yaml input file error in documentation

### DIFF
--- a/docs/doc_input_file.md
+++ b/docs/doc_input_file.md
@@ -50,8 +50,8 @@ key_mapping:
   E: total_energy            # total potential eneriges to train to
   F: forces                  # atomic forces to train to
   R: pos                     # raw atomic positions
-  unit_cell: cell
-  pbc: pbc
+  CELL: cell
+  PBC: pbc
 chemical_symbols:
   - Cu
   - I


### PR DESCRIPTION
The key_mapping keywords name doesn't match with .npz files generated in the workflow.
The wrong keywords will be ignored in NequIP training, and result in non PBC condiction when creating neighbor list.